### PR TITLE
Add public method is_lambda

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lambda-http-local"
-version = "0.1.0"
-authors = ["iliana destroyer of worlds <iliana@buttslol.net>"]
+version = "0.1.1"
+authors = ["iliana destroyer of worlds <iliana@buttslol.net>", "Will Springer <skirmisher@protonmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/iliana/lambda-http-local"
 edition = "2018"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ where
 {
     #[cfg(feature = "local")]
     {
-        if std::env::var_os("AWS_LAMBDA_RUNTIME_API").is_some() {
+        if is_lambda() {
             // AWS Lambda mode
             lambda(handler)
         } else {
@@ -88,6 +88,18 @@ where
     #[cfg(not(feature = "local"))]
     {
         lambda(handler)
+    }
+}
+
+pub fn is_lambda() -> bool {
+    #[cfg(feature = "local")]
+    {
+        return std::env::var_os("AWS_LAMBDA_RUNTIME_API").is_some();
+    }
+
+    #[cfg(not(feature = "local"))]
+    {
+        return true;
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,12 +94,12 @@ where
 pub fn is_lambda() -> bool {
     #[cfg(feature = "local")]
     {
-        return std::env::var_os("AWS_LAMBDA_RUNTIME_API").is_some();
+        std::env::var_os("AWS_LAMBDA_RUNTIME_API").is_some()
     }
 
     #[cfg(not(feature = "local"))]
     {
-        return true;
+        true
     }
 }
 


### PR DESCRIPTION
Useful if your project depends on other AWS infra (e.g. S3) which you want to conditionally replicate locally as well.